### PR TITLE
Add names for additional currencies, fixes

### DIFF
--- a/lang/de.php
+++ b/lang/de.php
@@ -71,6 +71,16 @@ $l_czk = "Tschechische Krone";
 $l_dkk = "Dänische Krone";
 $l_clp = "Chilenischer Peso";
 $l_mxn = "Mexikanischer Peso";
+$l_bch = "Bitcoin Cash";
+$l_bnb = "Binance Coin";
+$l_eos = "EOS.IO";
+$l_xrp = "Ripple";
+$l_xlm = "Stellar Lumens";
+$l_link = "Chainlink";
+$l_dot = "Polkadot";
+$l_yfi = "Yearn.Finance";
+$l_gel = "Georgischer Lari";
+$l_xdr = "Sonderziehungsrechte";
 
 // Weitere Monero Links
 $getmonero = '<a class="text-white" href="https://www.getmonero.org/de/" hreflang="de" target="_blank" rel="external">Offizielle Webseite</a> | <a class="text-white" href="https://ccs.getmonero.org/" hreflang="en" target="_blank" rel="external">Community Crowdfunding System (CCS)</a> | <a class="text-white" href="https://www.monero.observer/resources/" hreflang="en" target="_blank" rel="external">Monero Observer</a> | <a class="text-white" href="https://www.monerotalk.live/" hreflang="en" target="_blank" rel="external">Monero Talk</a>';

--- a/lang/el.php
+++ b/lang/el.php
@@ -71,6 +71,16 @@ $l_czk = "Czech Koruna";
 $l_dkk = "Danish Krone";
 $l_clp = "Chilean Peso";
 $l_mxn = "Mexican Peso";
+$l_bch = "Bitcoin Cash";
+$l_bnb = "Binance Coin";
+$l_eos = "EOS.IO";
+$l_xrp = "Ripple";
+$l_xlm = "Stellar Lumens";
+$l_link = "Chainlink";
+$l_dot = "Polkadot";
+$l_yfi = "Yearn.Finance";
+$l_gel = "Georgian Lari";
+$l_xdr = "Special Drawing Rights";
 
 // More Monero links
 $getmonero = '<a class="text-white" href="https://www.getmonero.org/el/" hreflang="el" target="_blank" rel="external">Official website</a> | <a class="text-white" href="https://ccs.getmonero.org/" hreflang="en" target="_blank" rel="external">Community Crowdfunding System (CCS)</a> | <a class="text-white" href="https://www.monero.observer/resources/" hreflang="en" target="_blank" rel="external">Monero Observer</a> | <a class="text-white" href="https://www.monerotalk.live/" hreflang="en" target="_blank" rel="external">Monero Talk</a>';

--- a/lang/en.php
+++ b/lang/en.php
@@ -71,6 +71,16 @@ $l_czk = "Czech Koruna";
 $l_dkk = "Danish Krone";
 $l_clp = "Chilean Peso";
 $l_mxn = "Mexican Peso";
+$l_bch = "Bitcoin Cash";
+$l_bnb = "Binance Coin";
+$l_eos = "EOS.IO";
+$l_xrp = "Ripple";
+$l_xlm = "Stellar Lumens";
+$l_link = "Chainlink";
+$l_dot = "Polkadot";
+$l_yfi = "Yearn.Finance";
+$l_gel = "Georgian Lari";
+$l_xdr = "Special Drawing Rights";
 
 // More Monero links
 $getmonero = '<a class="text-white" href="https://www.getmonero.org/" hreflang="en" target="_blank" rel="external">Official website</a> | <a class="text-white" href="https://ccs.getmonero.org/" hreflang="en" target="_blank" rel="external">Community Crowdfunding System (CCS)</a> | <a class="text-white" href="https://www.monero.observer/resources/" hreflang="en" target="_blank" rel="external">Monero Observer</a> | <a class="text-white" href="https://www.monerotalk.live/" hreflang="en" target="_blank" rel="external">Monero Talk</a>';

--- a/lang/es.php
+++ b/lang/es.php
@@ -71,6 +71,16 @@ $l_czk = "Corona checa";
 $l_dkk = "Corona danesa";
 $l_clp = "Peso chileno";
 $l_mxn = "Peso mexicano";
+$l_bch = "Bitcoin Cash";
+$l_bnb = "Binance Coin";
+$l_eos = "EOS.IO";
+$l_xrp = "Ripple";
+$l_xlm = "Stellar Lumens";
+$l_link = "Chainlink";
+$l_dot = "Polkadot";
+$l_yfi = "Yearn.Finance";
+$l_gel = "Lari Georgiano";
+$l_xdr = "Derechos Especiales de Giro";
 
 // More Monero links
 $getmonero = '<a class="text-white" href="https://www.getmonero.org/es/" hreflang="es" target="_blank" rel="external">Página oficial</a> | <a class="text-white" href="https://ccs.getmonero.org/" hreflang="en" target="_blank" rel="external">Community Crowdfunding System (CCS)</a> | <a class="text-white" href="https://www.monero.observer/resources/" hreflang="en" target="_blank" rel="external">Monero Observer</a> | <a class="text-white" href="https://www.monerotalk.live/" hreflang="en" target="_blank" rel="external">Monero Talk</a>';

--- a/lang/it.php
+++ b/lang/it.php
@@ -71,6 +71,16 @@ $l_czk = "Corona Ceca";
 $l_dkk = "Corona Danese";
 $l_clp = "Peso cileno";
 $l_mxn = "Peso messicano";
+$l_bch = "Bitcoin Cash";
+$l_bnb = "Binance Coin";
+$l_eos = "EOS.IO";
+$l_xrp = "Ripple";
+$l_xlm = "Stellar Lumens";
+$l_link = "Chainlink";
+$l_dot = "Polkadot";
+$l_yfi = "Yearn.Finance";
+$l_gel = "Lari Georgiano";
+$l_xdr = "Diritti Speciali di Prelievo";
 
 // Link di Monero
 $getmonero = '<a class="text-white" href="https://www.getmonero.org/it/" hreflang="it" target="_blank" rel="external">Sito ufficiale</a> | <a class="text-white" href="https://ccs.getmonero.org/" hreflang="en" target="_blank" rel="external">Community Crowdfunding System (CCS)</a> | <a class="text-white" href="https://www.monero.observer/resources/" hreflang="en" target="_blank" rel="external">Monero Observer</a> | <a class="text-white" href="https://www.monerotalk.live/" hreflang="en" target="_blank" rel="external">Monero Talk</a>';

--- a/lang/nl.php
+++ b/lang/nl.php
@@ -71,6 +71,16 @@ $l_czk = "Czech Koruna";
 $l_dkk = "Danish Krone";
 $l_clp = "Chilean Peso";
 $l_mxn = "Mexican Peso";
+$l_bch = "Bitcoin Cash";
+$l_bnb = "Binance Coin";
+$l_eos = "EOS.IO";
+$l_xrp = "Ripple";
+$l_xlm = "Stellar Lumens";
+$l_link = "Chainlink";
+$l_dot = "Polkadot";
+$l_yfi = "Yearn.Finance";
+$l_gel = "Georgian Lari";
+$l_xdr = "Special Drawing Rights";
 
 // More Monero links
 $getmonero = '<a class="text-white" href="https://www.getmonero.org/nl/" hreflang="nl" target="_blank" rel="external">Official website</a> | <a class="text-white" href="https://ccs.getmonero.org/" hreflang="en" target="_blank" rel="external">Community Crowdfunding System (CCS)</a> | <a class="text-white" href="https://www.monero.observer/resources/" hreflang="en" target="_blank" rel="external">Monero Observer</a> | <a class="text-white" href="https://www.monerotalk.live/" hreflang="en" target="_blank" rel="external">Monero Talk</a>';

--- a/lang/pl.php
+++ b/lang/pl.php
@@ -71,6 +71,16 @@ $l_czk = "Czech Koruna";
 $l_dkk = "Danish Krone";
 $l_clp = "Chilean Peso";
 $l_mxn = "Mexican Peso";
+$l_bch = "Bitcoin Cash";
+$l_bnb = "Binance Coin";
+$l_eos = "EOS.IO";
+$l_xrp = "Ripple";
+$l_xlm = "Stellar Lumens";
+$l_link = "Chainlink";
+$l_dot = "Polkadot";
+$l_yfi = "Yearn.Finance";
+$l_gel = "Georgian Lari";
+$l_xdr = "Special Drawing Rights";
 
 // More Monero links
 $getmonero = '<a class="text-white" href="https://www.getmonero.org/pl/" hreflang="pl" target="_blank" rel="external">Official website</a> | <a class="text-white" href="https://ccs.getmonero.org/" hreflang="en" target="_blank" rel="external">Community Crowdfunding System (CCS)</a> | <a class="text-white" href="https://www.monero.observer/resources/" hreflang="en" target="_blank" rel="external">Monero Observer</a> | <a class="text-white" href="https://www.monerotalk.live/" hreflang="en" target="_blank" rel="external">Monero Talk</a>';

--- a/lang/pt-br.php
+++ b/lang/pt-br.php
@@ -71,6 +71,16 @@ $l_czk = "Koruna tcheca";
 $l_dkk = "Krone dinamarquês";
 $l_clp = "Peso chileno";
 $l_mxn = "Peso mexicano";
+$l_bch = "Bitcoin Cash";
+$l_bnb = "Binance Coin";
+$l_eos = "EOS.IO";
+$l_xrp = "Ripple";
+$l_xlm = "Stellar Lumens";
+$l_link = "Chainlink";
+$l_dot = "Polkadot";
+$l_yfi = "Yearn.Finance";
+$l_gel = "Lari Georgiano";
+$l_xdr = "Direitos Especiais de Saque";
 
 // More Monero links
 $getmonero = '<a class="text-white" href="https://www.getmonero.org/pt-br/" hreflang="pt" target="_blank" rel="external">Site oficial</a> | <a class="text-white" href="https://ccs.getmonero.org/" hreflang="en" target="_blank" rel="external">Sistema de vaquinhas comunitárias (CCS)</a> | <a class="text-white" href="https://www.monero.observer/resources/" hreflang="en" target="_blank" rel="external">Monero Observer</a> | <a class="text-white" href="https://www.monerotalk.live/" hreflang="en" target="_blank" rel="external">Monero Talk</a>';

--- a/lang/ru.php
+++ b/lang/ru.php
@@ -71,6 +71,16 @@ $l_czk = "Чешская крона";
 $l_dkk = "Датская крона";
 $l_clp = "Чилийское песо";
 $l_mxn = "Мексиканское песо";
+$l_bch = "Биткойн Кэш";
+$l_bnb = "Бинанс Коин";
+$l_eos = "EOS.IO";
+$l_xrp = "Рипл";
+$l_xlm = "Стеллар Люменс";
+$l_link = "Чейнлинк";
+$l_dot = "Полкадот";
+$l_yfi = "Ерн.Файненс";
+$l_gel = "Грузинский Лари";
+$l_xdr = "Специальные права заимствования";
 
 // More Monero links
 $getmonero = '<a class="text-white" href="https://www.getmonero.org/ru/" hreflang="ru" target="_blank" rel="external">Официальный сайт</a> | <a class="text-white" href="https://ccs.getmonero.org/" hreflang="en" target="_blank" rel="external">Система краудфандинга для сообществ (CCS)</a> | <a class="text-white" href="https://www.monero.observer/resources/" hreflang="en" target="_blank" rel="external">Обозреватель Monero</a> | <a class="text-white" href="https://www.monerotalk.live/" hreflang="en" target="_blank" rel="external">Monero Talk</a>';

--- a/lang/zh-cn.php
+++ b/lang/zh-cn.php
@@ -71,6 +71,16 @@ $l_czk = "捷克克朗";
 $l_dkk = "丹麦克朗";
 $l_clp = "智利比索";
 $l_mxn = "墨西哥比索";
+$l_bch = "比特币现金";
+$l_bnb = "币安币";
+$l_eos = "EOS.IO";
+$l_xrp = "瑞波币";
+$l_xlm = "恒星币";
+$l_link = "链环";
+$l_dot = "波卡";
+$l_yfi = "Yearn.Finance";
+$l_gel = "格鲁吉亚拉里";
+$l_xdr = "特别提款权";
 
 // More Monero links
 $getmonero = '<a class="text-white" href="https://www.getmonero.org/zh-cn/" hreflang="zh-cn" target="_blank" rel="external">官方网站</a> | <a class="text-white" href="https://ccs.getmonero.org/" hreflang="en" target="_blank" rel="external">社区众筹系统 (CCS)</a> | <a class="text-white" href="https://www.monero.observer/resources/" hreflang="en" target="_blank" rel="external">门罗浏览器</a> | <a class="text-white" href="https://www.monerotalk.live/" hreflang="en" target="_blank" rel="external">Monero Talk播客</a>';

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -62,7 +62,8 @@ document.addEventListener('DOMContentLoaded', function () {
     }
   });
 
-  // Fetch updated exchange rates every 5 seconds
+  // Fetch updated exchange rates immediately, then every 5 seconds
+  fetchUpdatedExchangeRates();
   setInterval(fetchUpdatedExchangeRates, 5000);
 });
 

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -119,7 +119,7 @@ function fiatConvert(value) {
 
   if (exchangeRates[selectBox]) {
     let value = fiatAmount / exchangeRates[selectBox];
-    xmrValue.value = value.toFixed(selectBox == 'BTC' || selectBox == 'LTC' || selectBox == 'ETH' || selectBox == 'XAG' || selectBox == 'XAU' ? 8 : 2);
+    xmrValue.value = value.toFixed(8);
   }
 }
 

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -119,7 +119,7 @@ function fiatConvert(value) {
 
   if (exchangeRates[selectBox]) {
     let value = fiatAmount / exchangeRates[selectBox];
-    xmrValue.value = value.toFixed(8);
+    xmrValue.value = value.toFixed(12);
   }
 }
 


### PR DESCRIPTION
This PR adds names for BCH, BNB, EOS, XRP, XLM, LINK, DOT, YFI, GEL and XDR to the language files. Also ensures that XMR values display 12 digits (was 2 - 8 due to a copy-paste mistake).