### PR TITLE
Server-side calculations for JavaScript-free environments

### DIFF
--- a/index.php
+++ b/index.php
@@ -196,8 +196,8 @@ foreach (array_reverse($preferred_currencies) as $currency) {
 
                 <noscript>
                     <div class="alert alert-warning" role="alert">
-                        <p>Looks like you have JavaScript disabled. You can still use this tool, but you won't be able to use the &#128203; buttons to automatically copy the results to your clipboard.</p>
-                        <p>Use the &darr; button to convert XMR to fiat, or the &uarr; button to convert fiat to XMR.</p>
+                        Looks like you have JavaScript disabled. You can still use this tool, but you won't be able to use the &#128203; buttons to automatically copy the results to your clipboard.<br />
+                        Use the &darr; button to convert XMR to fiat, or the &uarr; button to convert fiat to XMR.
                     </div>
                 </noscript>
 
@@ -229,9 +229,6 @@ foreach (array_reverse($preferred_currencies) as $currency) {
         </div>
     </div>
 
-    <script>
-        var exchangeRates = <?php echo json_encode($exchangeRates); ?>;
-    </script>
     <script src="js/main.js"></script>
 </body>
 

--- a/index.php
+++ b/index.php
@@ -167,7 +167,7 @@ foreach (array_reverse($preferred_currencies) as $currency) {
                         <input class="input-group-text" id="basic-addon-xmr" type="text" value="XMR" aria-label="Monero" disabled>
                     </div>
 
-                    <div class="equals-box">
+                    <div class="equals-box mb-3">
                         <button id="convertXMRToFiat" type="submit" name="direction" value="0" class="btn btn-arrow">
                             <span class="equals-text">&darr;</span>
                         </button>
@@ -193,6 +193,13 @@ foreach (array_reverse($preferred_currencies) as $currency) {
                         </select>
                     </div>
                 </form>
+
+                <noscript>
+                    <div class="alert alert-warning" role="alert">
+                        <p>Looks like you have JavaScript disabled. You can still use this tool, but you won't be able to use the &#128203; buttons to automatically copy the results to your clipboard.</p>
+                        <p>Use the &darr; button to convert XMR to fiat, or the &uarr; button to convert fiat to XMR.</p>
+                    </div>
+                </noscript>
 
                 <hr class="gold" />
                 <small class="cursor-default text-white text-info" lang="<?php echo $lang_meta; ?>">

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -53,6 +53,31 @@ input.form-control {
     font-size: 42px;
 }
 
+.btn-arrow {
+    border: 1px solid white;
+    border-radius: 10px;
+    font-size: 38px !important;
+    color: white;
+    padding: 0;
+    cursor: pointer;
+}
+
+.btn-arrow:hover {
+    border: 1px solid black;
+    color: black;
+}
+
+.btn-equals {
+    font-size: 38px !important;
+    color: white;
+    padding: 0;
+    cursor: default;
+}
+
+.btn-equals:hover {
+    color: black;
+}
+
 .equals-text {
     vertical-align: super;
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -51,6 +51,7 @@ input.form-control {
     color: #e9ecef;
     font-weight: 800;
     font-size: 42px;
+    padding-bottom: 1;
 }
 
 .btn-arrow {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -14,6 +14,8 @@ console.log(tooltipList);
 
 let lastModifiedField = 'xmr';
 
+var exchangeRates = {};
+
 document.addEventListener('DOMContentLoaded', function () {
   const copyXMRBtn = document.getElementById('copyXMRBtn');
   const copyFiatBtn = document.getElementById('copyFiatBtn');

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -20,6 +20,8 @@ document.addEventListener('DOMContentLoaded', function () {
   const xmrInput = document.getElementById('xmrInput');
   const fiatInput = document.getElementById('fiatInput');
   const selectBox = document.getElementById('selectBox');
+  const convertXMRToFiatBtn = document.getElementById('convertXMRToFiat');
+  const convertFiatToXMRBtn = document.getElementById('convertFiatToXMR');
 
   // Add event listeners for the copy buttons
   copyXMRBtn.addEventListener('click', copyToClipBoardXMR);
@@ -60,6 +62,17 @@ document.addEventListener('DOMContentLoaded', function () {
     } else {
       fiatConvert(selectBox.value)
     }
+  });
+
+  // Add event listeners for the conversion buttons
+  convertXMRToFiatBtn.addEventListener('click', (e) => {
+    e.preventDefault();
+    xmrConvert();
+  });
+
+  convertFiatToXMRBtn.addEventListener('click', (e) => {
+    e.preventDefault();
+    fiatConvert();
   });
 
   // Fetch updated exchange rates immediately, then every 5 seconds

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -64,16 +64,9 @@ document.addEventListener('DOMContentLoaded', function () {
     }
   });
 
-  // Add event listeners for the conversion buttons
-  convertXMRToFiatBtn.addEventListener('click', (e) => {
-    e.preventDefault();
-    xmrConvert();
-  });
-
-  convertFiatToXMRBtn.addEventListener('click', (e) => {
-    e.preventDefault();
-    fiatConvert();
-  });
+  // Hide the conversion buttons if JavaScript is enabled
+  convertXMRToFiatBtn.style.display = 'none';
+  convertFiatToXMRBtn.style.display = 'none';
 
   // Fetch updated exchange rates immediately, then every 5 seconds
   fetchUpdatedExchangeRates();

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -31,7 +31,7 @@ module.exports = {
       paths: glob.sync([
         path.join(__dirname, 'index.php')
       ]),
-      safelist: ['tooltip', 'fade', 'show', 'bs-tooltip-top', 'tooltip-inner', 'tooltip-arrow', 'btn-equals', 'btn-arrow']
+      safelist: ['tooltip', 'fade', 'show', 'bs-tooltip-top', 'tooltip-inner', 'tooltip-arrow', 'btn-equals', 'btn-arrow', 'alert', 'alert-warning']
     })
   ]
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -31,7 +31,7 @@ module.exports = {
       paths: glob.sync([
         path.join(__dirname, 'index.php')
       ]),
-      safelist: ['tooltip', 'fade', 'show', 'bs-tooltip-top', 'tooltip-inner', 'tooltip-arrow']
+      safelist: ['tooltip', 'fade', 'show', 'bs-tooltip-top', 'tooltip-inner', 'tooltip-arrow', 'btn-equals', 'btn-arrow']
     })
   ]
 };


### PR DESCRIPTION
This PR implements conversion calculations directly within `index.php` so that the application can be used with disabled JavaScript. Users with disabled JavaScript will see a `<noscript>` message informing them about the slightly modified flow, involving arrow buttons for each "conversion direction".

The PR also introduces clearer separation between `index.php` and the JavaScript code by removing the conversion rate object from index.php, and fixes the image URL in the OpenGraph tags.