### PR TITLE
Haveno.markets as secondary data source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,10 @@
 # Secret files
 /secrets.php
 
+# Haveno.markets data
+/storage/haveno.json
+/storage/haveno.json.bak
+
 # Compiled files
 /public/js/
 /public/css/

--- a/lang/ar.php
+++ b/lang/ar.php
@@ -1,0 +1,76 @@
+<?php
+// For the HTML meta specification, e.g. <!DOCTYPE html><html lang="en">
+// https://www.w3schools.com/tags/ref_language_codes.asp
+$lang_meta = "ar";
+// The browser tab title or search engine title
+$page_title = "تحويل XMR إلى EUR/BTC/CHF/USD والكثير غير ذلك";
+// Search engine description / text
+$meta_description = "سعر الصرف المباشر للمونيرو بالعديد من العملات المختلفة.. مجاني للجميع.";
+// Search engine keywords
+$meta_keywords = "مونرو، XMR، فيات، قيمة، سعر، مباشر، تبادل، تحويل";
+// ↓ XMR [...] ↓
+$title_h1 = "التحويل إلى";
+$moneroooTable = "الخدمة مقدمة من <a href=\"https://moner.ooo/\">Moner.ooo</a> ، البيانات مقدمة من <a href=\"https://www.coingecko.com/ar/%D8%B9%D9%85%D9%84%D8%A7%D8%AA/monero\" hreflang=\"ar\" rel=\"external\">CoinGecko</a>";
+$unixTime = "وقت يونكس:";
+// Info Text
+$info = "أسعار الصرف على هذا الموقع هي لأغراض إعلامية فقط. لا نضمن دقتها، وهي عرضة للتغيير دون إشعار. يتم تحديث أسعار الصرف كل 5 ثوانٍ. آخر تحديث عند الساعة <u title=\"الساعات:الدقائق:الثواني (س س:د:ث)\">$time</u> ، أوروبا/برلين. البيانات مقدمة من <a class='text-white' href='https://www.coingecko.com/ar/%D8%B9%D9%85%D9%84%D8%A7%D8%AA/monero' hreflang='ar' rel='external' target='_blank'>CoinGecko</a> .<br/> <a target='_blank' href='https://kuno.anne.media/donate/onml/' rel='external' hreflang='en'><img loading='lazy' src='./img/kuno-monero-26x26.png' width='17' height='17' alt=\"كونو - صفحة التبرعات Moner.ooo\"></a> <a target='_blank' href='https://kuno.anne.media/lang/ar/' class='text-white' rel='external' hreflang='ar'>Kuno – جمع التبرعات باستخدام Monero</a> | <a class='text-white' href='https://github.com/nice42q/moner.ooo' hreflang='en' rel='external' target='_blank'>GitHub</a> | <a style='text-decoration:none; font-weight:bold;' class='text-white' href='https://servers.guru/' hreflang='en' rel='external' target='_blank'>استضافة الويب مقدمة من <img loading='lazy' src='./img/servers-guru.svg' height='19' alt='Servers Guru' title=\"سيرفر جورو\" /></a>";
+$clipboard_copy_tooltip = "نسخ إلى الحافظة";
+$l_fiatSelect = "اختيار العملة";
+$l_fiatInput = "حقل إدخال قيمة الفيات";
+$l_xmrInput = "حقل إدخال قيمة مونرو";
+// Tooltip Titel
+$l_eur = "اليورو";
+$l_btc = "البيتكوين";
+$l_chf = "الفرنك السويسري";
+$l_usd = "الدولار الأمريكي";
+$l_ltc = "اللايتكوين";
+$l_gbp = "الجنيه الاسترليني";
+$l_rub = "الروبل الروسي";
+$l_jpy = "الين";
+$l_try = "الليرة التركية";
+$l_cad = "الدولار الكندي";
+$l_aud = "الدولار الاسترالي";
+$l_hkd = "دولار هونج كونج";
+$l_sgd = "الدولار السنغافوري";
+$l_pln = "زلوتي";
+$l_zar = "الراند الجنوب أفريقي";
+$l_inr = "الروبية الهندية";
+$l_aed = "الدرهم الإماراتي";
+$l_eth = "الإيثيريوم";
+$l_uah = "هريفنا";
+$l_krw = "الوون الكوري الجنوبي";
+$l_brl = "الريال البرازيلي";
+$l_myr = "الرينغيت الماليزي";
+$l_cny = "الرنمينبي";
+$l_xag = "الفضة (الأونصة طروادة)";
+$l_xau = "الذهب (الاونصة طروادة)";
+$l_vnd = "دونج فيتنامي";
+$l_vef = "بوليفار فنزويلي";
+$l_thb = "باهت";
+$l_sar = "الريال السعودي";
+$l_sek = "الكرونة السويدية";
+$l_pkr = "الروبية الباكستانية";
+$l_nzd = "الدولار النيوزلندي";
+$l_php = "البيزو الفلبيني";
+$l_nok = "الكرونة النرويجية";
+$l_lkr = "الروبية السريلانكية";
+$l_mmk = "كيات ميانمار";
+$l_huf = "الفورنت المجري";
+$l_ils = "الشيكل الإسرائيلي الجديد";
+$l_kwd = "الدينار الكويتي";
+$l_ngn = "النيرة النيجيرية";
+$l_idr = "الروبية الإندونيسية";
+$l_twd = "الدولار التايواني الجديد";
+$l_ars = "البيزو الأرجنتيني";
+$l_bdt = "التاكا البنجلاديشية";
+$l_bhd = "الدينار البحريني";
+$l_bmd = "الدولار البرمودي";
+$l_czk = "الكورونا التشيكية";
+$l_dkk = "الكرونة الدنماركية";
+$l_clp = "البيزو التشيلي";
+$l_mxn = "البيزو المكسيكي";
+$l_gel = "اللاري الجورجي";
+// More Monero links
+$getmonero = '<a class="text-white" href="https://www.getmonero.org/ar/" hreflang="ar" target="_blank" rel="external">الموقع الرسمي</a> | <a class="text-white" href="https://ccs.getmonero.org/" hreflang="en" target="_blank" rel="external">نظام التمويل الجماعي المجتمعي (CCS)</a> | <a class="text-white" href="https://www.monero.observer/resources/" hreflang="en" target="_blank" rel="external">Monero Observer</a> | <a class="text-white" href="https://www.monerotalk.live/" hreflang="en" target="_blank" rel="external">Monero Talk</a>';
+$countrymonero = '';
+$rtl = 'true';

--- a/lang/es.php
+++ b/lang/es.php
@@ -83,6 +83,7 @@ $l_gel = "Lari Georgiano";
 $l_xdr = "Derechos Especiales de Giro";
 
 // More Monero links
-$getmonero = '<a class="text-white" href="https://www.getmonero.org/" hreflang="en" target="_blank" rel="external">Página oficial</a> | <a class="text-white" href="https://ccs.getmonero.org/" hreflang="en" target="_blank" rel="external">Sistema de Crowdfunding Comunitario (CCS)</a> | <a class="text-white" href="https://www.monero.observer/resources/" hreflang="en" target="_blank" rel="external">Explorador de Monero</a> | <a class="text-white" href="https://www.monerotalk.live/" hreflang="en" target="_blank" rel="external">Monero Talk</a>';
-$countrymonero = '&nbsp;| <a class="text-white" href="https://t.me/monero" hreflang="en" target="_blank" rel="external">Telegram - Monero XMR</a> | <a class="text-white" href="https://www.revuo-xmr.com/" hreflang="en" target="_blank" rel="external">Revuo Monero</a>';
+$getmonero = '<a class="text-white" href="https://www.getmonero.org/es/" hreflang="es" target="_blank" rel="external">Página oficial</a> | <a class="text-white" href="https://ccs.getmonero.org/" hreflang="en" target="_blank" rel="external">Sistema de Crowdfunding Comunitario (CCS)</a> | <a class="text-white" href="https://www.monero.observer/resources/" hreflang="en" target="_blank" rel="external">Explorador de Monero</a> | <a class="text-white" href="https://www.monerotalk.live/" hreflang="en" target="_blank" rel="external">Monero Talk</a>';
+$countrymonero = '&nbsp;| <a class="text-white" href="https://t.me/MoneroEsp" hreflang="en" target="_blank" rel="external">Telegram - Monero XMR en español</a>';
+$rtl = 'false';
 $unixTime = "Tiempo Unix:";

--- a/lang/fa.php
+++ b/lang/fa.php
@@ -16,6 +16,9 @@ $info = "نرخ‌های تبادل در این سایت فقط برای اطل�
 $servers_guru = " | <a style='text-decoration:none; font-weight:bold;' class='text-white' href='https://servers.guru/' hreflang='en' rel='external' target='_blank'>میزبانی وب ارائه شده توسط<img loading='lazy' src='./img/servers-guru.svg' height='19' alt='Servers Guru' title='Servers Guru' /></a>";
 
 $clipboard_copy_tooltip = "کپی به کلیپ‌بورد";
+$l_fiatSelect = "Currency choice";
+$l_fiatInput = "Fiat value input field";
+$l_xmrInput = "Monero value input field";
 
 // Tooltip Titel
 $l_eur = "یورو";

--- a/lang/pt.php
+++ b/lang/pt.php
@@ -70,8 +70,9 @@ $l_czk = "Koruna tcheca";
 $l_dkk = "Krone dinamarquês";
 $l_clp = "Peso chileno";
 $l_mxn = "Peso mexicano";
-$l_gel = "Georgian Lari";
+$l_gel = "Lari Georgiano";
 // More Monero links
 $getmonero = '<a class="text-white" href="https://www.getmonero.org/pt-br/" hreflang="pt" target="_blank" rel="external">Site oficial</a> | <a class="text-white" href="https://ccs.getmonero.org/" hreflang="en" target="_blank" rel="external">Sistema de vaquinhas comunitárias (CCS)</a> | <a class="text-white" href="https://www.monero.observer/resources/" hreflang="en" target="_blank" rel="external">Monero Observer</a> | <a class="text-white" href="https://www.monerotalk.live/" hreflang="en" target="_blank" rel="external">Monero Talk</a>';
 $countrymonero = '&nbsp;| <a class="text-white" href="https://t.me/monerobrasil" hreflang="en" target="_blank" rel="external">Telegram - Monero Brasil</a>';
-
+$rtl = 'false';
+$unixTime = "Unix Time:";

--- a/lang/ru.php
+++ b/lang/ru.php
@@ -84,3 +84,5 @@ $l_xdr = "Специальные права заимствования";
 // More Monero links
 $getmonero = '<a class="text-white" href="https://www.getmonero.org/ru/" hreflang="ru" target="_blank" rel="external">Официальный сайт</a> | <a class="text-white" href="https://ccs.getmonero.org/" hreflang="en" target="_blank" rel="external">Система краудфандинга для сообществ (CCS)</a> | <a class="text-white" href="https://www.monero.observer/resources/" hreflang="en" target="_blank" rel="external">Обозреватель Monero</a> | <a class="text-white" href="https://www.monerotalk.live/" hreflang="en" target="_blank" rel="external">Monero Talk</a>';
 $countrymonero = '&nbsp;| <a class="text-white" href="https://t.me/xmr_ru" hreflang="en" target="_blank" rel="external">Telegram - Monero XMR.RU</a>';
+$rtl = 'false';
+$unixTime = "Время Unix:";

--- a/lang/ta.php
+++ b/lang/ta.php
@@ -1,0 +1,76 @@
+<?php
+// For the HTML meta specification, e.g. <!DOCTYPE html><html lang="en">
+// https://www.w3schools.com/tags/ref_language_codes.asp
+$lang_meta = "ta";
+// The browser tab title or search engine title
+$page_title = "EUR/BTC/CHF/USD மற்றும் பலவற்றிற்கு எக்ச்எம்ஆர் மாற்றம்";
+// Search engine description / text
+$meta_description = "பல வேறுபட்ட நாணயங்களில் மோனெரோ நேரடி பரிமாற்ற வீதம், அனைவருக்கும் இலவசம்.";
+// Search engine keywords
+$meta_keywords = "மோனெரோ, எக்ச்எம்ஆர், ஃபியட், மதிப்பு, வீதம், நேரடி, பரிமாற்றம், மாற்றம்";
+// ↓ XMR [...] ↓
+$title_h1 = "மாற்ற";
+$moneroooTable = "Service provided by <a href='https://moner.ooo/'>Moner.ooo</a>, Data provided by <a href='https://www.coingecko.com/en/coins/monero' hreflang='en' rel='external'>CoinGecko</a>";
+$unixTime = "யூனிக்ச் நேரம்:";
+// Info Text
+$info = "இந்த தளத்தின் பரிமாற்ற விகிதங்கள் செய்தி நோக்கங்களுக்காக மட்டுமே. அவை துல்லியமானவை என்று பொறுப்பு அளிக்கப்படவில்லை, மேலும் அறிவிப்பு இல்லாமல் மாற்றத்திற்கு உட்பட்டவை. ஒவ்வொரு 5 விநாடிகளிலும் பரிமாற்ற விகிதங்கள் புதுப்பிக்கப்படுகின்றன. கடைசியாக <u title='மணிநேரம்:நிமிடங்கள்:விநாடிகள் (hh:mm:ss)'>$time</u> கடிகாரம், ஐரோப்பா/பெர்லின். Data provided by <a class='text-white' href='https://www.coingecko.com/en/coins/monero' hreflang='en' rel='external' target='_blank'>CoinGecko</a>.<br /><a target='_blank' href='https://kuno.anne.media/donate/onml/' rel='external' hreflang='en'><img loading='lazy' src='./img/kuno-monero-26x26.png' width='17' height='17' alt='Kuno - Moner.ooo donation page'></a>&nbsp;<a target='_blank' href='https://kuno.anne.media/' class='text-white' rel='external' hreflang='en'>Kuno – Fundraise with Monero</a> | <a class='text-white' href='https://github.com/nice42q/moner.ooo' hreflang='en' rel='external' target='_blank'>GitHub</a> | <a style='text-decoration:none; font-weight:bold;' class='text-white' href='https://servers.guru/' hreflang='en' rel='external' target='_blank'>Webhosting provided by<img loading='lazy' src='./img/servers-guru.svg' height='19' alt='Servers Guru' title='Servers Guru' /></a>";
+$clipboard_copy_tooltip = "இடைநிலைப்பலகைக்கு நகலெடுக்கவும்";
+$l_fiatSelect = "நாணய தேர்வு";
+$l_fiatInput = "ஃபியட் மதிப்பு உள்ளீட்டு புலம்";
+$l_xmrInput = "மோனெரோ மதிப்பு உள்ளீட்டு புலம்";
+// Tooltip Titel
+$l_eur = "யூரோ";
+$l_btc = "பிட்காயின்";
+$l_chf = "சுவிச் ஃபிராங்க்";
+$l_usd = "அமெரிக்க டாலர்";
+$l_ltc = "லிட்காயின்";
+$l_gbp = "பவுண்ட் ச்டெர்லிங்";
+$l_rub = "ரச்ய ரூபிள்";
+$l_jpy = "யென்";
+$l_try = "துருக்கிய லிரா";
+$l_cad = "கனடிய டாலர்";
+$l_aud = "ஆச்திரேலிய டாலர்";
+$l_hkd = "ஆங்காங் டாலர்";
+$l_sgd = "சிங்கப்பூர் டாலர்";
+$l_pln = "கோல்டன்";
+$l_zar = "தென்னாப்பிரிக்க ரேண்ட்";
+$l_inr = "இந்திய ரூபாய்";
+$l_aed = "யுஏஇ திர்உாம்";
+$l_eth = "Ethereum";
+$l_uah = "உர்ரிவ்னியா";
+$l_krw = "தென் கொரியன் வென்றார்";
+$l_brl = "பிரேசிலிய உண்மையான";
+$l_myr = "மலேசிய ரிங்கிட்";
+$l_cny = "ரென்மின்பி";
+$l_xag = "வெள்ளி (டிராய் அவுன்ச்)";
+$l_xau = "தங்கம் (டிராய் அவுன்ச்)";
+$l_vnd = "வியட்நாமிய டோங்";
+$l_vef = "வெனிசுலா பொலிவர்";
+$l_thb = "பாட்";
+$l_sar = "சவுதி ரியால்";
+$l_sek = "ச்வீடிச் க்ரோனா";
+$l_pkr = "என் பேக் தொடங்குகிறது";
+$l_nzd = "நியூசிலாந்து டாலர்";
+$l_php = "பிலிப்பைன்ச் பெசோ";
+$l_nok = "நோர்வே க்ரோன்";
+$l_lkr = "இலங்கை தொடங்குகிறது";
+$l_mmk = "மியான்மர் கியாட்";
+$l_huf = "அங்கேரியன்";
+$l_ils = "இச்ரேலிய புதிய செகல்";
+$l_kwd = "குவைத் தினார்";
+$l_ngn = "நைசீரிய நைரா";
+$l_idr = "இந்தோனேசிய ரூபியா";
+$l_twd = "புதிய தைவான் டாலர்";
+$l_ars = "அர்சென்டினா பெசோ";
+$l_bdt = "பங்களாதேசி";
+$l_bhd = "பஉரைன் தினார்";
+$l_bmd = "பெர்முடன் டாலர்";
+$l_czk = "செக் கொருனா";
+$l_dkk = "டேனிச் க்ரோன்";
+$l_clp = "சிலி பெசோ";
+$l_mxn = "மெக்சிகன் பெசோ";
+$l_gel = "சார்சியன் ரன்கள்";
+// More Monero links
+$getmonero = '<a class="text-white" href="https://www.getmonero.org/" hreflang="en" target="_blank" rel="external">அதிகாரப்பூர்வ வலைத்தளம்</a> | <a class="text-white" href="https://ccs.getmonero.org/" hreflang="en" target="_blank" rel="external">சமூக கூட்ட நெரிசல் அமைப்பு (CCS)</a> | <a class="text-white" href="https://www.monero.observer/resources/" hreflang="en" target="_blank" rel="external">Monero பார்வையாளர்</a> | <a class="text-white" href="https://www.monerotalk.live/" hreflang="en" target="_blank" rel="external">Monero Talk</a>';
+$countrymonero = '';
+$rtl = 'false';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-	"name": "monerooo3",
+	"name": "moner.ooo",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
@@ -8,23 +8,46 @@
 				"@popperjs/core": "^2.11.8",
 				"bootstrap": "^5.3.3",
 				"webpack": "^5.91.0",
-				"webpack-cli": "^5.1.4"
+				"webpack-cli": "^6.0.0"
 			},
 			"devDependencies": {
 				"css-loader": "^7.1.2",
 				"glob-all": "^3.3.1",
 				"mini-css-extract-plugin": "^2.9.0",
-				"purgecss": "^6.0.0",
+				"purgecss": "^7.0.0",
 				"purgecss-webpack-plugin": "^6.0.0"
 			}
 		},
 		"node_modules/@discoveryjs/json-ext": {
-			"version": "0.5.7",
-			"resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
-			"integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.6.3.tgz",
+			"integrity": "sha512-4B4OijXeVNOPZlYA2oEwWOTkzyltLao+xbotHQeqN++Rv27Y6s818+n2Qkp8q+Fxhn0t/5lA5X1Mxktud8eayQ==",
 			"license": "MIT",
 			"engines": {
-				"node": ">=10.0.0"
+				"node": ">=14.17.0"
+			}
+		},
+		"node_modules/@isaacs/balanced-match": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
+			"integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
+		"node_modules/@isaacs/brace-expansion": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
+			"integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@isaacs/balanced-match": "^4.0.1"
+			},
+			"engines": {
+				"node": "20 || >=22"
 			}
 		},
 		"node_modules/@isaacs/cliui": {
@@ -131,17 +154,13 @@
 			}
 		},
 		"node_modules/@jridgewell/gen-mapping": {
-			"version": "0.3.8",
-			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
-			"integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
+			"version": "0.3.12",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.12.tgz",
+			"integrity": "sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==",
 			"license": "MIT",
 			"dependencies": {
-				"@jridgewell/set-array": "^1.2.1",
-				"@jridgewell/sourcemap-codec": "^1.4.10",
+				"@jridgewell/sourcemap-codec": "^1.5.0",
 				"@jridgewell/trace-mapping": "^0.3.24"
-			},
-			"engines": {
-				"node": ">=6.0.0"
 			}
 		},
 		"node_modules/@jridgewell/resolve-uri": {
@@ -153,19 +172,10 @@
 				"node": ">=6.0.0"
 			}
 		},
-		"node_modules/@jridgewell/set-array": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
-			"integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
 		"node_modules/@jridgewell/source-map": {
-			"version": "0.3.6",
-			"resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
-			"integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
+			"version": "0.3.10",
+			"resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.10.tgz",
+			"integrity": "sha512-0pPkgz9dY+bijgistcTTJ5mR+ocqRXLuhXHYdzoMmmoJ2C9S46RCm2GMUbatPEUK9Yjy26IrAy8D/M00lLkv+Q==",
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/gen-mapping": "^0.3.5",
@@ -173,15 +183,15 @@
 			}
 		},
 		"node_modules/@jridgewell/sourcemap-codec": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-			"integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+			"version": "1.5.4",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.4.tgz",
+			"integrity": "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==",
 			"license": "MIT"
 		},
 		"node_modules/@jridgewell/trace-mapping": {
-			"version": "0.3.25",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-			"integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+			"version": "0.3.29",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.29.tgz",
+			"integrity": "sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.1.0",
@@ -230,9 +240,9 @@
 			}
 		},
 		"node_modules/@types/estree": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
-			"integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+			"integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
 			"license": "MIT"
 		},
 		"node_modules/@types/json-schema": {
@@ -242,12 +252,12 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "22.13.10",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.10.tgz",
-			"integrity": "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==",
+			"version": "24.0.15",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.15.tgz",
+			"integrity": "sha512-oaeTSbCef7U/z7rDeJA138xpG3NuKc64/rZ2qmUFkFJmnMsAPaluIifqyWd8hSSMxyP9oie3dLAqYPblag9KgA==",
 			"license": "MIT",
 			"dependencies": {
-				"undici-types": "~6.20.0"
+				"undici-types": "~7.8.0"
 			}
 		},
 		"node_modules/@webassemblyjs/ast": {
@@ -397,42 +407,42 @@
 			}
 		},
 		"node_modules/@webpack-cli/configtest": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-2.1.1.tgz",
-			"integrity": "sha512-wy0mglZpDSiSS0XHrVR+BAdId2+yxPSoJW8fsna3ZpYSlufjvxnP4YbKTCBZnNIcGN4r6ZPXV55X4mYExOfLmw==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-3.0.1.tgz",
+			"integrity": "sha512-u8d0pJ5YFgneF/GuvEiDA61Tf1VDomHHYMjv/wc9XzYj7nopltpG96nXN5dJRstxZhcNpV1g+nT6CydO7pHbjA==",
 			"license": "MIT",
 			"engines": {
-				"node": ">=14.15.0"
+				"node": ">=18.12.0"
 			},
 			"peerDependencies": {
-				"webpack": "5.x.x",
-				"webpack-cli": "5.x.x"
+				"webpack": "^5.82.0",
+				"webpack-cli": "6.x.x"
 			}
 		},
 		"node_modules/@webpack-cli/info": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-2.0.2.tgz",
-			"integrity": "sha512-zLHQdI/Qs1UyT5UBdWNqsARasIA+AaF8t+4u2aS2nEpBQh2mWIVb8qAklq0eUENnC5mOItrIB4LiS9xMtph18A==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-3.0.1.tgz",
+			"integrity": "sha512-coEmDzc2u/ffMvuW9aCjoRzNSPDl/XLuhPdlFRpT9tZHmJ/039az33CE7uH+8s0uL1j5ZNtfdv0HkfaKRBGJsQ==",
 			"license": "MIT",
 			"engines": {
-				"node": ">=14.15.0"
+				"node": ">=18.12.0"
 			},
 			"peerDependencies": {
-				"webpack": "5.x.x",
-				"webpack-cli": "5.x.x"
+				"webpack": "^5.82.0",
+				"webpack-cli": "6.x.x"
 			}
 		},
 		"node_modules/@webpack-cli/serve": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-2.0.5.tgz",
-			"integrity": "sha512-lqaoKnRYBdo1UgDX8uF24AfGMifWK19TxPmM5FHc2vAGxrJ/qtyUyFBWoY1tISZdelsQ5fBcOusifo5o5wSJxQ==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-3.0.1.tgz",
+			"integrity": "sha512-sbgw03xQaCLiT6gcY/6u3qBDn01CWw/nbaXl3gTdTFuJJ75Gffv3E3DBpgvY2fkkrdS1fpjaXNOmJlnbtKauKg==",
 			"license": "MIT",
 			"engines": {
-				"node": ">=14.15.0"
+				"node": ">=18.12.0"
 			},
 			"peerDependencies": {
-				"webpack": "5.x.x",
-				"webpack-cli": "5.x.x"
+				"webpack": "^5.82.0",
+				"webpack-cli": "6.x.x"
 			},
 			"peerDependenciesMeta": {
 				"webpack-dev-server": {
@@ -453,15 +463,27 @@
 			"license": "Apache-2.0"
 		},
 		"node_modules/acorn": {
-			"version": "8.14.1",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
-			"integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
+			"version": "8.15.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
 			"license": "MIT",
 			"bin": {
 				"acorn": "bin/acorn"
 			},
 			"engines": {
 				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/acorn-import-phases": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
+			"integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.13.0"
+			},
+			"peerDependencies": {
+				"acorn": "^8.14.0"
 			}
 		},
 		"node_modules/ajv": {
@@ -543,9 +565,9 @@
 			"license": "MIT"
 		},
 		"node_modules/bootstrap": {
-			"version": "5.3.3",
-			"resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.3.tgz",
-			"integrity": "sha512-8HLCdWgyoMguSO9o+aH+iuZ+aht+mzW0u3HIMzVu7Srrpv7EBBxTnrFlSCskwdY1+EOFQSm7uMJhNQHkdPcmjg==",
+			"version": "5.3.7",
+			"resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.7.tgz",
+			"integrity": "sha512-7KgiD8UHjfcPBHEpDNg+zGz8L3LqR3GVwqZiBRFX04a1BCArZOz1r2kjly2HQ0WokqTO0v1nF+QAt8dsW4lKlw==",
 			"funding": [
 				{
 					"type": "github",
@@ -562,9 +584,9 @@
 			}
 		},
 		"node_modules/brace-expansion": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -573,9 +595,9 @@
 			}
 		},
 		"node_modules/browserslist": {
-			"version": "4.24.4",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
-			"integrity": "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==",
+			"version": "4.25.1",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.1.tgz",
+			"integrity": "sha512-KGj0KoOMXLpSNkkEI6Z6mShmQy0bc1I+T7K9N81k4WWMrfz+6fQ6es80B/YLAeRoKvjYE1YSHHOW1qe9xIVzHw==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -592,10 +614,10 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001688",
-				"electron-to-chromium": "^1.5.73",
+				"caniuse-lite": "^1.0.30001726",
+				"electron-to-chromium": "^1.5.173",
 				"node-releases": "^2.0.19",
-				"update-browserslist-db": "^1.1.1"
+				"update-browserslist-db": "^1.1.3"
 			},
 			"bin": {
 				"browserslist": "cli.js"
@@ -621,9 +643,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001703",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001703.tgz",
-			"integrity": "sha512-kRlAGTRWgPsOj7oARC9m1okJEXdL/8fekFVcxA8Hl7GH4r/sN4OJn/i6Flde373T50KS7Y37oFbMwlE8+F42kQ==",
+			"version": "1.0.30001727",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001727.tgz",
+			"integrity": "sha512-pB68nIHmbN6L/4C6MH1DokyR3bYqFwjaSs/sWDHGj4CTcFtQUQMuJftVwWkXq7mNWOybD3KhUv3oWHoGxgP14Q==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -705,7 +727,6 @@
 			"version": "12.1.0",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
 			"integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
@@ -799,9 +820,9 @@
 			"license": "MIT"
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.114",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.114.tgz",
-			"integrity": "sha512-DFptFef3iktoKlFQK/afbo274/XNWD00Am0xa7M8FZUepHlHT8PEuiNBoRfFHbH1okqN58AlhbJ4QTkcnXorjA==",
+			"version": "1.5.187",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.187.tgz",
+			"integrity": "sha512-cl5Jc9I0KGUoOoSbxvTywTa40uspGJt/BDBoDLoxJRSBpWh4FFXBsjNRHfQrONsV/OoEjDfHUmZQa2d6Ze4YgA==",
 			"license": "ISC"
 		},
 		"node_modules/emoji-regex": {
@@ -812,9 +833,9 @@
 			"license": "MIT"
 		},
 		"node_modules/enhanced-resolve": {
-			"version": "5.18.1",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.1.tgz",
-			"integrity": "sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==",
+			"version": "5.18.2",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.2.tgz",
+			"integrity": "sha512-6Jw4sE1maoRJo3q8MsSIn2onJFbLTOjY9hlx4DZXmOKvLRd1Ok2kXmAGXaafL2+ijsJZ1ClYbl/pmqr9+k4iUQ==",
 			"license": "MIT",
 			"dependencies": {
 				"graceful-fs": "^4.2.4",
@@ -837,9 +858,9 @@
 			}
 		},
 		"node_modules/es-module-lexer": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.6.0.tgz",
-			"integrity": "sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==",
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+			"integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
 			"license": "MIT"
 		},
 		"node_modules/escalade": {
@@ -1331,9 +1352,9 @@
 			}
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.9",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.9.tgz",
-			"integrity": "sha512-SppoicMGpZvbF1l3z4x7No3OlIjP7QJvC9XR7AhZr1kL133KHnKPztkKDc+Ir4aJ/1VhTySrtKhrsycmrMQfvg==",
+			"version": "3.3.11",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+			"integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
 			"dev": true,
 			"funding": [
 				{
@@ -1484,9 +1505,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.3",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
-			"integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
+			"version": "8.5.6",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+			"integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
 			"dev": true,
 			"funding": [
 				{
@@ -1504,7 +1525,7 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"nanoid": "^3.3.8",
+				"nanoid": "^3.3.11",
 				"picocolors": "^1.1.1",
 				"source-map-js": "^1.2.1"
 			},
@@ -1597,16 +1618,16 @@
 			"license": "MIT"
 		},
 		"node_modules/purgecss": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/purgecss/-/purgecss-6.0.0.tgz",
-			"integrity": "sha512-s3EBxg5RSWmpqd0KGzNqPiaBbWDz1/As+2MzoYVGMqgDqRTLBhJW6sywfTBek7OwNfoS/6pS0xdtvChNhFj2cw==",
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/purgecss/-/purgecss-7.0.2.tgz",
+			"integrity": "sha512-4Ku8KoxNhOWi9X1XJ73XY5fv+I+hhTRedKpGs/2gaBKU8ijUiIKF/uyyIyh7Wo713bELSICF5/NswjcuOqYouQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"commander": "^12.0.0",
-				"glob": "^10.3.10",
-				"postcss": "^8.4.4",
-				"postcss-selector-parser": "^6.0.7"
+				"commander": "^12.1.0",
+				"glob": "^11.0.0",
+				"postcss": "^8.4.47",
+				"postcss-selector-parser": "^6.1.2"
 			},
 			"bin": {
 				"purgecss": "bin/purgecss.js"
@@ -1626,17 +1647,17 @@
 				"webpack": ">=5.0.0"
 			}
 		},
-		"node_modules/purgecss/node_modules/brace-expansion": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+		"node_modules/purgecss-webpack-plugin/node_modules/brace-expansion": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0"
 			}
 		},
-		"node_modules/purgecss/node_modules/glob": {
+		"node_modules/purgecss-webpack-plugin/node_modules/glob": {
 			"version": "10.4.5",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
 			"integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
@@ -1657,7 +1678,7 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"node_modules/purgecss/node_modules/minimatch": {
+		"node_modules/purgecss-webpack-plugin/node_modules/minimatch": {
 			"version": "9.0.5",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
 			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
@@ -1668,6 +1689,119 @@
 			},
 			"engines": {
 				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/purgecss-webpack-plugin/node_modules/postcss-selector-parser": {
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+			"integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cssesc": "^3.0.0",
+				"util-deprecate": "^1.0.2"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/purgecss-webpack-plugin/node_modules/purgecss": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/purgecss/-/purgecss-6.0.0.tgz",
+			"integrity": "sha512-s3EBxg5RSWmpqd0KGzNqPiaBbWDz1/As+2MzoYVGMqgDqRTLBhJW6sywfTBek7OwNfoS/6pS0xdtvChNhFj2cw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"commander": "^12.0.0",
+				"glob": "^10.3.10",
+				"postcss": "^8.4.4",
+				"postcss-selector-parser": "^6.0.7"
+			},
+			"bin": {
+				"purgecss": "bin/purgecss.js"
+			}
+		},
+		"node_modules/purgecss/node_modules/glob": {
+			"version": "11.0.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-11.0.3.tgz",
+			"integrity": "sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"foreground-child": "^3.3.1",
+				"jackspeak": "^4.1.1",
+				"minimatch": "^10.0.3",
+				"minipass": "^7.1.2",
+				"package-json-from-dist": "^1.0.0",
+				"path-scurry": "^2.0.0"
+			},
+			"bin": {
+				"glob": "dist/esm/bin.mjs"
+			},
+			"engines": {
+				"node": "20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/purgecss/node_modules/jackspeak": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
+			"integrity": "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"@isaacs/cliui": "^8.0.2"
+			},
+			"engines": {
+				"node": "20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/purgecss/node_modules/lru-cache": {
+			"version": "11.1.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.1.0.tgz",
+			"integrity": "sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
+		"node_modules/purgecss/node_modules/minimatch": {
+			"version": "10.0.3",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.3.tgz",
+			"integrity": "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"@isaacs/brace-expansion": "^5.0.0"
+			},
+			"engines": {
+				"node": "20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/purgecss/node_modules/path-scurry": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
+			"integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"lru-cache": "^11.0.0",
+				"minipass": "^7.1.2"
+			},
+			"engines": {
+				"node": "20 || >=22"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
@@ -1796,9 +1930,9 @@
 			"license": "MIT"
 		},
 		"node_modules/schema-utils": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.0.tgz",
-			"integrity": "sha512-Gf9qqc58SpCA/xdziiHz35F4GNIWYWZrEshUc/G/r5BnLph6xpKuLeoJoQuj5WfBIx/eQLf+hmVPYHaxJu7V2g==",
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.2.tgz",
+			"integrity": "sha512-Gn/JaSk/Mt9gYubxTtSn/QCV4em9mpAPiR1rqy/Ocu19u/G9J5WWdNoUT4SiV6mFC3y6cxyFcFwdzPM3FgxGAQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/json-schema": "^7.0.9",
@@ -1815,9 +1949,9 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "7.7.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-			"integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+			"version": "7.7.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+			"integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -2004,22 +2138,22 @@
 			}
 		},
 		"node_modules/tapable": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
-			"integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.2.tgz",
+			"integrity": "sha512-Re10+NauLTMCudc7T5WLFLAwDhQ0JWdrMK+9B2M8zR5hRExKmsRDCBA7/aV/pNJFltmBFO5BAMlQFi/vq3nKOg==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
 		},
 		"node_modules/terser": {
-			"version": "5.39.0",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-5.39.0.tgz",
-			"integrity": "sha512-LBAhFyLho16harJoWMg/nZsQYgTrg5jXOn2nCYjRUcZZEdE3qa2zb8QEDRUGVZBW4rlazf2fxkg8tztybTaqWw==",
+			"version": "5.43.1",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.43.1.tgz",
+			"integrity": "sha512-+6erLbBm0+LROX2sPXlUYx/ux5PyE9K/a92Wrt6oA+WDAoFTdpHE5tCYCI5PNzq2y8df4rA+QgHLJuR4jNymsg==",
 			"license": "BSD-2-Clause",
 			"dependencies": {
 				"@jridgewell/source-map": "^0.3.3",
-				"acorn": "^8.8.2",
+				"acorn": "^8.14.0",
 				"commander": "^2.20.0",
 				"source-map-support": "~0.5.20"
 			},
@@ -2071,9 +2205,9 @@
 			"license": "MIT"
 		},
 		"node_modules/undici-types": {
-			"version": "6.20.0",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-			"integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+			"integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
 			"license": "MIT"
 		},
 		"node_modules/update-browserslist-db": {
@@ -2114,9 +2248,9 @@
 			"license": "MIT"
 		},
 		"node_modules/watchpack": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.2.tgz",
-			"integrity": "sha512-TnbFSbcOCcDgjZ4piURLCbJ3nJhznVh9kw6F6iokjiFPl8ONxe9A6nMDVXDiNbrSfLILs6vB07F7wLBrwPYzJw==",
+			"version": "2.4.4",
+			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.4.tgz",
+			"integrity": "sha512-c5EGNOiyxxV5qmTtAB7rbiXxi1ooX1pQKMLX/MIabJjRA0SJBQOjKF+KSVfHkr9U1cADPon0mRiVe/riyaiDUA==",
 			"license": "MIT",
 			"dependencies": {
 				"glob-to-regexp": "^0.4.1",
@@ -2127,20 +2261,22 @@
 			}
 		},
 		"node_modules/webpack": {
-			"version": "5.98.0",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.98.0.tgz",
-			"integrity": "sha512-UFynvx+gM44Gv9qFgj0acCQK2VE1CtdfwFdimkapco3hlPCJ/zeq73n2yVKimVbtm+TnApIugGhLJnkU6gjYXA==",
+			"version": "5.100.2",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.100.2.tgz",
+			"integrity": "sha512-QaNKAvGCDRh3wW1dsDjeMdDXwZm2vqq3zn6Pvq4rHOEOGSaUMgOOjG2Y9ZbIGzpfkJk9ZYTHpDqgDfeBDcnLaw==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/eslint-scope": "^3.7.7",
-				"@types/estree": "^1.0.6",
+				"@types/estree": "^1.0.8",
+				"@types/json-schema": "^7.0.15",
 				"@webassemblyjs/ast": "^1.14.1",
 				"@webassemblyjs/wasm-edit": "^1.14.1",
 				"@webassemblyjs/wasm-parser": "^1.14.1",
-				"acorn": "^8.14.0",
+				"acorn": "^8.15.0",
+				"acorn-import-phases": "^1.0.3",
 				"browserslist": "^4.24.0",
 				"chrome-trace-event": "^1.0.2",
-				"enhanced-resolve": "^5.17.1",
+				"enhanced-resolve": "^5.17.2",
 				"es-module-lexer": "^1.2.1",
 				"eslint-scope": "5.1.1",
 				"events": "^3.2.0",
@@ -2150,11 +2286,11 @@
 				"loader-runner": "^4.2.0",
 				"mime-types": "^2.1.27",
 				"neo-async": "^2.6.2",
-				"schema-utils": "^4.3.0",
+				"schema-utils": "^4.3.2",
 				"tapable": "^2.1.1",
 				"terser-webpack-plugin": "^5.3.11",
 				"watchpack": "^2.4.1",
-				"webpack-sources": "^3.2.3"
+				"webpack-sources": "^3.3.3"
 			},
 			"bin": {
 				"webpack": "bin/webpack.js"
@@ -2173,42 +2309,39 @@
 			}
 		},
 		"node_modules/webpack-cli": {
-			"version": "5.1.4",
-			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.1.4.tgz",
-			"integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-6.0.1.tgz",
+			"integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
 			"license": "MIT",
 			"dependencies": {
-				"@discoveryjs/json-ext": "^0.5.0",
-				"@webpack-cli/configtest": "^2.1.1",
-				"@webpack-cli/info": "^2.0.2",
-				"@webpack-cli/serve": "^2.0.5",
+				"@discoveryjs/json-ext": "^0.6.1",
+				"@webpack-cli/configtest": "^3.0.1",
+				"@webpack-cli/info": "^3.0.1",
+				"@webpack-cli/serve": "^3.0.1",
 				"colorette": "^2.0.14",
-				"commander": "^10.0.1",
+				"commander": "^12.1.0",
 				"cross-spawn": "^7.0.3",
-				"envinfo": "^7.7.3",
+				"envinfo": "^7.14.0",
 				"fastest-levenshtein": "^1.0.12",
 				"import-local": "^3.0.2",
 				"interpret": "^3.1.1",
 				"rechoir": "^0.8.0",
-				"webpack-merge": "^5.7.3"
+				"webpack-merge": "^6.0.1"
 			},
 			"bin": {
 				"webpack-cli": "bin/cli.js"
 			},
 			"engines": {
-				"node": ">=14.15.0"
+				"node": ">=18.12.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/webpack"
 			},
 			"peerDependencies": {
-				"webpack": "5.x.x"
+				"webpack": "^5.82.0"
 			},
 			"peerDependenciesMeta": {
-				"@webpack-cli/generators": {
-					"optional": true
-				},
 				"webpack-bundle-analyzer": {
 					"optional": true
 				},
@@ -2217,33 +2350,24 @@
 				}
 			}
 		},
-		"node_modules/webpack-cli/node_modules/commander": {
-			"version": "10.0.1",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-			"integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=14"
-			}
-		},
 		"node_modules/webpack-merge": {
-			"version": "5.10.0",
-			"resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-			"integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-6.0.1.tgz",
+			"integrity": "sha512-hXXvrjtx2PLYx4qruKl+kyRSLc52V+cCvMxRjmKwoA+CBbbF5GfIBtR6kCvl0fYGqTUPKB+1ktVmTHqMOzgCBg==",
 			"license": "MIT",
 			"dependencies": {
 				"clone-deep": "^4.0.1",
 				"flat": "^5.0.2",
-				"wildcard": "^2.0.0"
+				"wildcard": "^2.0.1"
 			},
 			"engines": {
-				"node": ">=10.0.0"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/webpack-sources": {
-			"version": "3.2.3",
-			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
-			"integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.3.tgz",
+			"integrity": "sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=10.13.0"

--- a/package.json
+++ b/package.json
@@ -6,13 +6,13 @@
 		"css-loader": "^7.1.2",
 		"glob-all": "^3.3.1",
 		"mini-css-extract-plugin": "^2.9.0",
-		"purgecss": "^6.0.0",
+		"purgecss": "^7.0.0",
 		"purgecss-webpack-plugin": "^6.0.0"
 	},
 	"dependencies": {
 		"@popperjs/core": "^2.11.8",
 		"bootstrap": "^5.3.3",
 		"webpack": "^5.91.0",
-		"webpack-cli": "^5.1.4"
+		"webpack-cli": "^6.0.0"
 	}
 }

--- a/public/haveno.php
+++ b/public/haveno.php
@@ -1,0 +1,68 @@
+<?php
+
+// Set default timezone
+date_default_timezone_set('Europe/Berlin');
+
+// Define the base URL for the Haveno API
+$haveno_api_base_url = "https://haveno.markets/api/v1";
+$haveno_json_path = dirname(__DIR__) . '/storage/haveno.json';
+
+// Fetch the previously stored data
+$previousData = file_exists($haveno_json_path) ? json_decode(file_get_contents($haveno_json_path), true) : ['time' => 0];
+$output = $previousData;
+
+$currentTime = time();
+
+// Check if five seconds have passed since the last update
+if (($currentTime - $previousData['time']) >= 5) {
+    // Fetch the ticker data from Haveno API
+    $tickerUrl = $haveno_api_base_url . "/tickers";
+
+    $tickerCh = curl_init($tickerUrl);
+    curl_setopt($tickerCh, CURLOPT_RETURNTRANSFER, true);
+    $tickerJson = curl_exec($tickerCh);
+
+    $tickerHttpCode = curl_getinfo($tickerCh, CURLINFO_HTTP_CODE);
+    curl_close($tickerCh);
+
+    if ($tickerHttpCode == 200) {
+        $tickers = json_decode($tickerJson, true);
+
+        // Initialize new data array
+        $newData = ['time' => $currentTime];
+
+        // Process each ticker to get XMR exchange rates
+        foreach ($tickers as $ticker) {
+            $pair = strtolower($ticker['pair']);
+            if (strpos($pair, 'xmr_') === 0) {
+                // Extract the currency from market pair (e.g., xmr_usd -> usd)
+                $currency = substr($pair, 4);
+
+                // Store the last price as the exchange rate
+                $newData[$currency] = [
+                    'lastValue' => floatval($ticker['last_price']),
+                    'lastDate' => $currentTime
+                ];
+            } elseif (strpos($pair, '_xmr') !== false) {
+                // Extract the currency from market pair (e.g., usd_xmr -> usd)
+                $currency = substr($pair, 0, strpos($pair, '_xmr'));
+
+                // Store the last price as the exchange rate
+                $newData[$currency] = [
+                    'lastValue' => 1 / floatval($ticker['last_price']), // Inverse for XMR to fiat
+                    'lastDate' => $currentTime
+                ];
+            }
+        }
+
+        // Save the new data to JSON files
+        file_put_contents($haveno_json_path, json_encode($newData, JSON_PRETTY_PRINT));
+        file_put_contents($haveno_json_path . ".bak", json_encode($tickers, JSON_PRETTY_PRINT));
+
+        $output = $newData;
+    }
+}
+
+// Output the data
+header('Content-Type: application/json');
+echo json_encode($output, JSON_PRETTY_PRINT);

--- a/public/index.php
+++ b/public/index.php
@@ -5,6 +5,7 @@ header("Cache-Control: post-check=0, pre-check=0", false);
 header("Pragma: no-cache");
 
 $COINGECKO_JSON_PATH = dirname(__DIR__) . '/storage/coingecko.json';
+$HAVENO_JSON_PATH = dirname(__DIR__) . '/storage/haveno.json';
 
 $protocol = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off' || $_SERVER['SERVER_PORT'] == 443) ? "https://" : "http://";
 $currentUrl = $protocol . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
@@ -12,17 +13,37 @@ $parentUrl = dirname($currentUrl);
 
 // Get currency data from JSON
 `php coingecko.php`;
-
-if (!file_exists($COINGECKO_JSON_PATH)) {
-    sleep(1);
-}
-
-$api_cg = json_decode(file_get_contents($COINGECKO_JSON_PATH), true);
+`php haveno.php`;
 
 // Configuration file
 $config = [];
 if (file_exists(dirname(__DIR__) . '/config.php')) {
     $config = require_once '../config.php';
+}
+
+// Handle data source selection from URL parameter
+if (isset($_GET['data_source']) && in_array($_GET['data_source'], ['coingecko', 'haveno'])) {
+    $data_source = $_GET['data_source'];
+} else {
+    $data_source = isset($config['data_source']) ? $config['data_source'] : 'coingecko';
+}
+
+// Get currency data from JSON based on data source
+if ($data_source === 'haveno') {
+    if (!file_exists($HAVENO_JSON_PATH)) {
+        sleep(1);
+    }
+    $api_data = json_decode(file_get_contents($HAVENO_JSON_PATH), true);
+    $source_name = 'Haveno.markets';
+    $source_url = 'https://haveno.markets';
+} else {
+    // Default to CoinGecko
+    if (!file_exists($COINGECKO_JSON_PATH)) {
+        sleep(1);
+    }
+    $api_data = json_decode(file_get_contents($COINGECKO_JSON_PATH), true);
+    $source_name = 'CoinGecko';
+    $source_url = 'https://www.coingecko.com/en/coins/monero';
 }
 
 $display_servers_guru = isset($config['servers_guru']) && $config['servers_guru'] === true;
@@ -32,17 +53,46 @@ $github_url = isset($config['github_url']) ? $config['github_url'] : 'https://gi
 $footer_html = isset($config['footer_html']) ? $config['footer_html'] : '';
 
 // Extract the keys
-$currencies = array_map('strtoupper', array_keys($api_cg));
+$currencies = array_map('strtoupper', array_keys($api_data));
 
 // Fetch the time of the last API data update
-$time_cg = date("H:i:s", $api_cg['time']);
-$time = $time_cg;
+$time = date("H:i:s", $api_data['time']);
 unset($currencies[array_search('TIME', $currencies)]);
+
+// Order preferred currencies to the top
+foreach (array_reverse($preferred_currencies) as $currency) {
+    $currency = strtoupper($currency);
+    if (($key = array_search($currency, $currencies)) !== false) {
+        unset($currencies[$key]);
+        array_unshift($currencies, $currency);
+    }
+}
+
+// Check if the selected currency is available in the current data source
+$xmr_in = isset($_GET["in"]) ? strtoupper(string: htmlspecialchars($_GET["in"])) : 'EUR';
+
+if (!in_array($xmr_in, $currencies)) {
+    // If not available, fall back to a default currency that should be available in both sources
+    $fallback_currencies = ['USD', 'BTC', 'EUR'];
+    foreach ($fallback_currencies as $fallback) {
+        if (in_array($fallback, $currencies)) {
+            $xmr_in = $fallback;
+            break;
+        }
+    }
+    // If none of the fallbacks are available, just use the first available currency
+    if (!in_array($xmr_in, $currencies)) {
+        $xmr_in = $currencies[0];
+    }
+}
 
 // Populate exchange rates
 $exchangeRates = [];
 foreach ($currencies as $currency) {
-    $exchangeRates[$currency] = $api_cg[strtolower($currency)]['lastValue'];
+    $currencyLower = strtolower($currency);
+    if (isset($api_data[$currencyLower]) && isset($api_data[$currencyLower]['lastValue'])) {
+        $exchangeRates[$currency] = $api_data[$currencyLower]['lastValue'];
+    }
 }
 
 // Get the primary language from the browser
@@ -98,14 +148,9 @@ $xmr_value = number_format($xmr_value, 12);
 
 $fiat_value = strtr($fiat_value, ",", " ");
 
-// Order preferred currencies to the top
-foreach (array_reverse($preferred_currencies) as $currency) {
-    $currency = strtoupper($currency);
-    if (($key = array_search($currency, $currencies)) !== false) {
-        unset($currencies[$key]);
-        array_unshift($currencies, $currency);
-    }
-}
+// Include the data source in the info text
+$info = str_replace('CoinGecko', $source_name, $info);
+$info = str_replace('https://www.coingecko.com/en/coins/monero', $source_url, $info);
 
 // Output the HTML
 require_once '../templates/index.php';

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -82,6 +82,10 @@ input.form-control {
     vertical-align: super;
 }
 
+a {
+    display: inline flow-root;
+}
+
 p {
     color: #cecece;
 }
@@ -162,4 +166,34 @@ p {
 
 #donation-qr-toggle:checked ~ #donation-qr-container {
     display: flex;
+}
+
+.data-source-selector {
+    margin-top: 10px;
+    margin-bottom: 15px;
+}
+
+.data-source-selector .btn-group {
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.data-source-selector .btn {
+    font-size: 0.75rem;
+    padding: 0.25rem 0.5rem;
+    font-weight: 600;
+}
+
+.data-source-selector .btn-primary {
+    background-color: #ff6600;
+    border-color: #ff6600;
+}
+
+.data-source-selector .btn-outline-secondary {
+    color: #e9ecef;
+    border-color: #4d4d4d;
+}
+
+.data-source-selector .btn-outline-secondary:hover {
+    background-color: #4d4d4d;
+    color: white;   
 }

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -19,40 +19,39 @@ let lastModifiedField = 'xmr';
 const exchangeRates = {};
 
 const runConvert = () =>
-    lastModifiedField === 'xmr' ? xmrConvert() : fiatConvert();
+  lastModifiedField === 'xmr' ? xmrConvert() : fiatConvert();
 
 let updateInterval
 const startFetching = () => updateInterval = setInterval(fetchUpdatedExchangeRates, fetchInterval);
 const stopFetching = () => {
-    clearInterval(updateInterval)
-    updateInterval = null;
+  clearInterval(updateInterval)
+  updateInterval = null;
 };
 
 let lastActivity = Date.now()
 
 const resetActivity = () => lastActivity = Date.now()
 const checkInactivity = () => {
-    if (Date.now() - lastActivity > inactivityTimeout) {
-        console.log('Inactivity detected, stopping exchange rate updates');
-        stopFetching();
-    } else {
-        requestAnimationFrame(checkInactivity);
-    }
+  if (Date.now() - lastActivity > inactivityTimeout) {
+    console.log('Inactivity detected, stopping exchange rate updates');
+    stopFetching();
+  } else {
+    requestAnimationFrame(checkInactivity);
+  }
 }
-
 document.addEventListener('focus', () => {
-    const focused = document.hasFocus();
-    console.log(`Page is ${focused ? 'visible' : 'hidden'}`); 
+  const focused = document.hasFocus();
+  console.log(`Page is ${focused ? 'visible' : 'hidden'}`);
 
-    if (focused && !updateInterval) {
-        console.log('Restarting exchange rate updates');
-        startFetching();
+  if (focused && !updateInterval) {
+    console.log('Restarting exchange rate updates');
+    startFetching();
 
-        resetActivity();
-        requestAnimationFrame(checkInactivity);
-    } else {
-        stopFetching();
-    }
+    resetActivity();
+    requestAnimationFrame(checkInactivity);
+  } else {
+    stopFetching();
+  }
 });
 window.addEventListener('mousemove', resetActivity);
 window.addEventListener('keydown', resetActivity);
@@ -61,129 +60,159 @@ window.addEventListener('touchstart', resetActivity);
 requestAnimationFrame(checkInactivity);
 
 document.addEventListener('DOMContentLoaded', () => {
-    const copyXMRBtn = document.getElementById('copyXMRBtn');
-    const copyFiatBtn = document.getElementById('copyFiatBtn');
-    const xmrInput = document.getElementById('xmrInput');
-    const fiatInput = document.getElementById('fiatInput');
-    const selectBox = document.getElementById('selectBox');
-    const convertXMRToFiatBtn = document.getElementById('convertXMRToFiat');
-    const convertFiatToXMRBtn = document.getElementById('convertFiatToXMR');
-    const fiatButtons = document.querySelectorAll('.fiat-btn');
-    
-    // Add event listeners for the currency buttons
-    fiatButtons.forEach(button => {
-        button.addEventListener('click', (e) => {
-            e.preventDefault();
-            selectBox.value = button.textContent;
-            runConvert();
-            history.pushState(null, '', `?in=${button.textContent}`);
-        });
-    });
-    
-    // Add event listeners for the copy buttons
-    copyXMRBtn.addEventListener('click', copyToClipboardXMR);
-    copyFiatBtn.addEventListener('click', copyToClipboardFiat);
-    
-    // Add event listeners for the XMR input field
-    xmrInput.addEventListener('change', xmrConvert);
-    xmrInput.addEventListener('keyup', () => {
-        xmrInput.value = xmrInput.value.replace(/[^\.^,\d]/g, '').replace(/\,/, '.');
-        if (xmrInput.value.split('.').length > 2) {
-            xmrInput.value = xmrInput.value.slice(0, -1);
+  const copyXMRBtn = document.getElementById('copyXMRBtn');
+  const copyFiatBtn = document.getElementById('copyFiatBtn');
+  const xmrInput = document.getElementById('xmrInput');
+  const fiatInput = document.getElementById('fiatInput');
+  const selectBox = document.getElementById('selectBox');
+  const convertXMRToFiatBtn = document.getElementById('convertXMRToFiat');
+  const convertFiatToXMRBtn = document.getElementById('convertFiatToXMR');
+  const fiatButtons = document.querySelectorAll('.fiat-btn');
+  const dataSourceButtons = document.querySelectorAll('.data-source-btn')[0]?.getElementsByTagName('a');
+
+  // Add event listeners for the currency buttons
+  fiatButtons.forEach(button => {
+    button.addEventListener('click', (e) => {
+      e.preventDefault();
+      selectBox.value = button.textContent;
+      runConvert();
+
+      // Update the currency in the data source buttons
+      if (dataSourceButtons) {
+        for (const dataSourceButton of dataSourceButtons) {
+          dataSourceButton.href = "?in=" + button.textContent + "&data_source=" + getCurrentDataSource();
         }
-        xmrConvert();
+      }
+      history.pushState(null, '', `?in=${button.textContent}&data_source=${getCurrentDataSource()}`);
     });
-    xmrInput.addEventListener('input', () => lastModifiedField = 'xmr');
-    
-    // Add event listeners for the fiat input field
-    fiatInput.addEventListener('change', fiatConvert);
-    fiatInput.addEventListener('keyup', () => {
-        fiatInput.value = fiatInput.value.replace(/[^\.^,\d]/g, '').replace(/\,/, '.');
-        if (fiatInput.value.split('.').length > 2) {
-            fiatInput.value = fiatInput.value.slice(0, -1);
-        }
-        fiatConvert();
-    });
-    fiatInput.addEventListener('input', () => lastModifiedField = 'fiat');
-    
-    // Add event listener for the select box to change the conversion
-    selectBox.addEventListener('change', runConvert);
-    
-    // Hide the conversion buttons if JavaScript is enabled
-    convertXMRToFiatBtn.style.display = 'none';
-    convertFiatToXMRBtn.style.display = 'none';
-    
-    // Fetch updated exchange rates immediately, then every 5 seconds
-    fetchUpdatedExchangeRates(true)
-    startFetching();
+  });
+
+  // Add event listeners for the copy buttons
+  copyXMRBtn.addEventListener('click', copyToClipboardXMR);
+  copyFiatBtn.addEventListener('click', copyToClipboardFiat);
+
+  // Add event listeners for the XMR input field
+  xmrInput.addEventListener('change', xmrConvert);
+  xmrInput.addEventListener('keyup', () => {
+    xmrInput.value = xmrInput.value.replace(/[^\.^,\d]/g, '').replace(/\,/, '.');
+    if (xmrInput.value.split('.').length > 2) {
+      xmrInput.value = xmrInput.value.slice(0, -1);
+    }
+    xmrConvert();
+  });
+  xmrInput.addEventListener('input', () => lastModifiedField = 'xmr');
+
+  // Add event listeners for the fiat input field
+  fiatInput.addEventListener('change', fiatConvert);
+  fiatInput.addEventListener('keyup', () => {
+    fiatInput.value = fiatInput.value.replace(/[^\.^,\d]/g, '').replace(/\,/, '.');
+    if (fiatInput.value.split('.').length > 2) {
+      fiatInput.value = fiatInput.value.slice(0, -1);
+    }
+    fiatConvert();
+  });
+  fiatInput.addEventListener('input', () => lastModifiedField = 'fiat');
+
+  // Add event listener for the select box to change the conversion
+  selectBox.addEventListener('change', runConvert);
+
+  // Hide the conversion buttons if JavaScript is enabled
+  convertXMRToFiatBtn.style.display = 'none';
+  convertFiatToXMRBtn.style.display = 'none';
+
+  // Fetch updated exchange rates immediately, then at the defined interval
+  fetchUpdatedExchangeRates(true);
+  startFetching();
 });
 
+function getCurrentDataSource() {
+  // Check for data_source in URL parameters
+  const urlParams = new URLSearchParams(window.location.search);
+  if (urlParams.has('data_source')) {
+    return urlParams.get('data_source');
+  }
+  // Check for cookie
+  const cookieValue = document.cookie
+    .split('; ')
+    .find(row => row.startsWith('preferred_data_source='));
+  if (cookieValue) {
+    return cookieValue.split('=')[1];
+  }
+  // Default to CoinGecko
+  return 'coingecko';
+}
+
 function fetchUpdatedExchangeRates(showAlert = false) {
-    fetch('/coingecko.php')
+  const dataSource = getCurrentDataSource();
+  const endpoint = dataSource === 'haveno' ? 'haveno.php' : 'coingecko.php';
+
+  fetch(endpoint)
     .then(response => response.json())
     .then(data => {
-        // Update the exchangeRates object with the new values
-        for (const [currency, value] of Object.entries(data)) {
-            exchangeRates[currency.toUpperCase()] = value.lastValue;
+      // Update the exchangeRates object with the new values
+      for (const [currency, value] of Object.entries(data)) {
+        if (currency !== 'time') {
+          exchangeRates[currency.toUpperCase()] = value.lastValue;
         }
-        
-        updateTimeElement(data.time);
-        
-        // Re-execute the appropriate conversion function
-        runConvert();
+      }
+
+      updateTimeElement(data.time);
+
+      // Re-execute the appropriate conversion function
+      runConvert();
     })
     .catch(e => {
-        const msg = `Error fetching exchange rates: ${e}`;
-        showAlert ? alert(msg) : console.error(msg);
+      const msg = `Error fetching exchange rates: ${e}`;
+      showAlert ? alert(msg) : console.error(msg);
     });
 }
 
 function updateTimeElement(unixTimestamp) {
-    const date = new Date(unixTimestamp * 1000);
-    const hours = String(date.getHours()).padStart(2, '0');
-    const minutes = String(date.getMinutes()).padStart(2, '0');
-    const seconds = String(date.getSeconds()).padStart(2, '0');
-    const formattedTime = `${hours}:${minutes}:${seconds}`;
-    
-    const u = document.querySelector('u');
-    u.textContent = formattedTime;
-    u.parentElement.innerHTML = u.parentElement.innerHTML.replace('Europe/Berlin', Intl.DateTimeFormat().resolvedOptions().timeZone);
+  const date = new Date(unixTimestamp * 1000);
+  const hours = String(date.getHours()).padStart(2, '0');
+  const minutes = String(date.getMinutes()).padStart(2, '0');
+  const seconds = String(date.getSeconds()).padStart(2, '0');
+  const formattedTime = `${hours}:${minutes}:${seconds}`;
+
+  const u = document.querySelector('u');
+  u.textContent = formattedTime;
+  u.parentElement.innerHTML = u.parentElement.innerHTML.replace('Europe/Berlin', Intl.DateTimeFormat().resolvedOptions().timeZone);
 }
 
 function copyToClipboardXMR() {
-    const content = document.getElementById('xmrInput');
-    content.select();
-    
-    // Using deprecated execCommand for compatibility with older browsers
-    document.execCommand('copy');
+  const content = document.getElementById('xmrInput');
+  content.select();
+
+  // Using deprecated execCommand for compatibility with older browsers
+  document.execCommand('copy');
 }
 
 function copyToClipboardFiat() {
-    const content = document.getElementById('fiatInput');
-    content.select();
-    
-    // Using deprecated execCommand for compatibility with older browsers
-    document.execCommand('copy');
+  const content = document.getElementById('fiatInput');
+  content.select();
+
+  // Using deprecated execCommand for compatibility with older browsers
+  document.execCommand('copy');
 }
 
 function fiatConvert() {
-    const fiatAmount = document.getElementById('fiatInput').value;
-    const xmrValue = document.getElementById('xmrInput');
-    const selectBox = document.getElementById('selectBox').value;
-    
-    if (exchangeRates[selectBox]) {
-        const value = fiatAmount / exchangeRates[selectBox];
-        xmrValue.value = value.toFixed(12);
-    }
+  const fiatAmount = document.getElementById('fiatInput').value;
+  const xmrValue = document.getElementById('xmrInput');
+  const selectBox = document.getElementById('selectBox').value;
+
+  if (exchangeRates[selectBox]) {
+    const value = fiatAmount / exchangeRates[selectBox];
+    xmrValue.value = value.toFixed(12);
+  }
 }
 
 function xmrConvert() {
-    const xmrAmount = document.getElementById('xmrInput').value;
-    const fiatValue = document.getElementById('fiatInput');
-    const selectBox = document.getElementById('selectBox').value;
-    
-    if (exchangeRates[selectBox]) {
-        const value = xmrAmount * exchangeRates[selectBox];
-        fiatValue.value = value.toFixed(['BTC', 'LTC', 'ETH', 'XAG', 'XAU'].includes(selectBox) ? 8 : 2);
-    }
+  const xmrAmount = document.getElementById('xmrInput').value;
+  const fiatValue = document.getElementById('fiatInput');
+  const selectBox = document.getElementById('selectBox').value;
+
+  if (exchangeRates[selectBox]) {
+    const value = xmrAmount * exchangeRates[selectBox];
+    fiatValue.value = value.toFixed(['BTC', 'LTC', 'ETH', 'XAG', 'XAU'].includes(selectBox) ? 8 : 2);
+  }
 }

--- a/templates/index.php
+++ b/templates/index.php
@@ -72,7 +72,7 @@
                                     echo "<tr>";
                                     foreach ($chunk as $currency) {
                                         $currencyName = isset(${"l_" . strtolower($currency)}) ? ${"l_" . strtolower($currency)} : $currency;
-                                        echo "<td><a href=\"/?in={$currency}\" class=\"btn btn-light fiat-btn\" title=\"{$currencyName}\" data-toggle=\"tooltip\" data-bs-html=\"true\" data-placement=\"top\">{$currency}</a></td>";
+                                        echo "<td><a href=\"/?in={$currency}&data_source={$data_source}\" class=\"btn btn-light fiat-btn\" title=\"{$currencyName}\" data-toggle=\"tooltip\" data-bs-html=\"true\" data-placement=\"top\">{$currency}</a></td>";
                                     }
                                     echo "</tr>";
                                     echo "<tr style=\"display:none;\">";
@@ -84,11 +84,36 @@
                                 ?>
                             </tbody>
                         </table>
+                        <div class="data-source-selector text-center mb-3">
+                            <span class="text-white">Data source:</span>
+                            <br />
+                            <div class="btn-group btn-group-sm data-source-btn" role="group" aria-label="Data source selection">
+                                <a href="?data_source=coingecko<?php echo isset($_GET['in']) ? '&in=' . $_GET['in'] : ''; ?>"
+                                    class="btn <?php echo $data_source == 'coingecko' ? 'btn-primary' : 'btn-outline-secondary'; ?>">
+                                    CoinGecko
+                                </a>
+                                <a href="?data_source=haveno<?php echo isset($_GET['in']) ? '&in=' . $_GET['in'] : ''; ?>"
+                                    class="btn <?php echo $data_source == 'haveno' ? 'btn-primary' : 'btn-outline-secondary'; ?>">
+                                    Haveno.markets
+                                </a>
+                            </div>
+                        </div>
                     </div>
                 </div>
                 <hr class="gold" />
 
+                <?php
+                if (strtolower(isset($_GET["in"]) && $_GET["in"] != $xmr_in)) {
+                ?>
+                    <div class="alert alert-warning alert-dismissible fade show" role="alert">
+                        <strong>Currency Changed:</strong> <?php echo htmlspecialchars($_GET["in"]); ?> is not available in this data source. Switched to <?php echo $xmr_in; ?>.
+                    </div>
+                <?php
+                }
+                ?>
+
                 <form method="get" action="">
+                    <input type="hidden" name="data_source" value="<?php echo $data_source; ?>" />
                     <div class="input-group mb-3">
                         <button id="copyXMRBtn" class="btn-outline-secondary input-group-text clipboard-copy" title="<?php echo $clipboard_copy_tooltip; ?>" data-toggle="tooltip" data-bs-html="true" data-placement="top">&#128203;</button>
                         <input class="form-control" id="xmrInput" name="xmr" type="text" spellcheck="false" autocorrect="off" inputmode="numeric" aria-label="<?php echo $l_xmrInput; ?>" aria-describedby="basic-addon-xmr" value="<?php echo $xmr_value; ?>">


### PR DESCRIPTION
As requested by @rottenwheel, this PR merges the Haveno.markets integration from monerooo.private.coffee as a secondary source for exchange rates.

This also merges in a bunch of other upstream changes and dependency updates which I will not list individually - the commit history is quite easy to read in that regard.